### PR TITLE
[ENH] Add support to auto-generate a barebones docstring

### DIFF
--- a/pybindgen/cppclass.py
+++ b/pybindgen/cppclass.py
@@ -2205,6 +2205,10 @@ typedef struct {
         if self.binary_numeric_operators:
             tp_flags.add("Py_TPFLAGS_CHECKTYPES")            
         self.slots.setdefault("tp_flags", '|'.join(tp_flags))
+
+        if docstring is None:
+            docstring = self.generate_docstring()
+
         self.slots.setdefault("tp_doc", (docstring is None and 'NULL'
                                          or "\"%s\"" % (docstring,)))
         dict_ = self.slots
@@ -2227,6 +2231,10 @@ typedef struct {
 
         self.pytype.generate(code_sink)
 
+    def generate_docstring(self):
+        name = self.get_python_name()
+        return "\\n".join(sorted([c.generate_docstring(name) for c in self.constructors],
+                                 key=len, reverse=True))
 
     def _generate_constructor(self, code_sink):
         """generate the constructor, if any"""

--- a/pybindgen/function.py
+++ b/pybindgen/function.py
@@ -289,9 +289,21 @@ class Function(ForwardWrapperBase):
         assert isinstance(self.wrapper_return, string_types)
         assert isinstance(self.wrapper_actual_name, string_types)
         assert isinstance(self.wrapper_args, list)
+
+        if self.docstring is None:
+            self.docstring = self.generate_docstring(name)
+
         return "{(char *) \"%s\", (PyCFunction) %s, %s, %s }," % \
                (name, self.wrapper_actual_name, '|'.join(flags),
                 (self.docstring is None and "NULL" or ('"'+self.docstring+'"')))
+
+    def generate_docstring(self, name):
+        parameters = self.parameters
+        signature = "{0}({1})".format(name, ", ".join([p.name for p in parameters]))
+        params = "\\n".join(["type: {0}: {1}".format(p.name, p.ctype)
+                             for p in parameters])
+        string = signature + "\\n\\n" + params
+        return string
 
 
 class CustomFunctionWrapper(Function):


### PR DESCRIPTION
Hello,

This is a follow-up to the (old) issue I had opened on Launchpad. This adds docstring auto-generation functionality:

- For methods and functions, it generates a signature + type info that follows the Sphinx convention, i.e.
```python
my_function(arg1, arg2)

type: arg1: my_type
type: arg2: my_type
```

- For constructors, it is the same but with a twist: as a cppclass can have multiple construcotrs, I put them all in tp_doc, sorted in reverse length order. This is to ensure that the "most complex" one comes on top. There are no type indicators in that case.

The generation of docstring for cppmethod and function should probably be merged somewhere !

This is a WIP, but if you have any comments/remarks !