### PR TITLE
Added Python 3.5+ compatibility fix

### DIFF
--- a/pybindgen/utils.py
+++ b/pybindgen/utils.py
@@ -111,7 +111,11 @@ typedef intobjargproc ssizeobjargproc;
 
     code_sink.writeln(r'''
 #if PY_VERSION_HEX >= 0x03000000
+#if PY_VERSION_HEX >= 0x03050000
+typedef PyAsyncMethods* cmpfunc;
+#else
 typedef void* cmpfunc;
+#endif
 #define PyCObject_FromVoidPtr(a, b) PyCapsule_New(a, NULL, b)
 #define PyCObject_AsVoidPtr(a) PyCapsule_GetPointer(a, NULL)
 #define PyString_FromString(a) PyBytes_FromString(a)


### PR DESCRIPTION
I have tested this fix with Python 2.7 (though it is obvious that it shouldn't be affected by this change), 3.4, 3.5, and 3.6.

Without this fix, I get the following compilation error when I integrate with C++ library:

```
error: invalid conversion from ‘cmpfunc {aka void*}’ to ‘PyAsyncMethods*’
```

Other than that, it seems like PyBindGen works fine with Python 3.5+!

Thank you for this great project!