### PR TITLE
Adds support for Py_LIMITED_API

### DIFF
--- a/pybindgen/container.py
+++ b/pybindgen/container.py
@@ -308,8 +308,8 @@ typedef struct {
     ''' % (self.pystruct, self.full_name, self.iter_pystruct))
 
         code_sink.writeln()
-        code_sink.writeln('extern PyTypeObject %s;' % (self.pytypestruct,))
-        code_sink.writeln('extern PyTypeObject %s;' % (self.iter_pytypestruct,))
+        code_sink.writeln('extern PyTypeObject _TYPEDEC %s;' % (self.pytypestruct,))
+        code_sink.writeln('extern PyTypeObject _TYPEDEC %s;' % (self.iter_pytypestruct,))
         code_sink.writeln()
 
         this_type_converter = self.module.get_root().get_python_to_c_type_converter_function_name(
@@ -346,18 +346,25 @@ typedef struct {
 
         ## --- register the class type in the module ---
         module.after_init.write_code("/* Register the '%s' class */" % self.full_name)
+        #import traceback; module.after_init.write_code(repr(traceback.format_stack()))
 
-        module.after_init.write_error_check('PyType_Ready(&%s)' % (self.pytypestruct,))
-        module.after_init.write_error_check('PyType_Ready(&%s)' % (self.iter_pytypestruct,))
+        module.after_init.write_code('#ifdef Py_LIMITED_API\n'
+                                     '%s = (PyTypeObject*)PyType_FromSpec(&%s_spec);\n'
+                                     '%s = (PyTypeObject*)PyType_FromSpec(&%s_spec);\n'
+                                     '#endif' % (self.pytypestruct, self.pytypestruct,
+                                                 self.iter_pytypestruct, self.iter_pytypestruct))
+
+        module.after_init.write_error_check('PyType_Ready(_TYPEREF %s)' % (self.pytypestruct,))
+        module.after_init.write_error_check('PyType_Ready(_TYPEREF %s)' % (self.iter_pytypestruct,))
 
         class_python_name = self.python_name
 
         if self.outer_class is None:
             module.after_init.write_code(
-                'PyModule_AddObject(m, (char *) \"%s\", (PyObject *) &%s);' % (
+                'PyModule_AddObject(m, (char *) \"%s\", (PyObject *) _TYPEREF %s);' % (
                 class_python_name, self.pytypestruct))
             module.after_init.write_code(
-                'PyModule_AddObject(m, (char *) \"%s\", (PyObject *) &%s);' % (
+                'PyModule_AddObject(m, (char *) \"%s\", (PyObject *) _TYPEREF %s);' % (
                 class_python_name+'Iter', self.iter_pytypestruct))
         else:
             module.after_init.write_code(
@@ -438,10 +445,13 @@ static void
 %s(%s *self)
 {
     %s
+    #ifdef Py_LIMITED_API
+    PyObject_DEL(self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
-''' % (container_tp_dealloc_function_name, self.pystruct,
-       self._get_container_delete_code()))
+''' % (container_tp_dealloc_function_name, self.pystruct, self._get_container_delete_code()))
 
         self.pytype.slots.setdefault("tp_dealloc", container_tp_dealloc_function_name )
 
@@ -454,7 +464,11 @@ static void
 {
     Py_CLEAR(self->container);
     %s
+    #ifdef Py_LIMITED_API
+    PyObject_DEL(self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 ''' % (iter_tp_dealloc_function_name, self.iter_pystruct, self._get_iter_delete_code()))
 
@@ -478,7 +492,7 @@ static void
 static PyObject*
 %(CONTAINER_ITER_FUNC)s(%(PYSTRUCT)s *self)
 {
-    %(ITER_PYSTRUCT)s *iter = PyObject_GC_New(%(ITER_PYSTRUCT)s, &%(ITER_PYTYPESTRUCT)s);
+    %(ITER_PYSTRUCT)s *iter = PyObject_GC_New(%(ITER_PYSTRUCT)s, _TYPEREF %(ITER_PYTYPESTRUCT)s);
     Py_INCREF(self);
     iter->container = self;
     iter->iterator = new %(CTYPE)s::iterator(self->obj->begin());
@@ -542,7 +556,7 @@ int %(CONTAINER_CONVERTER_FUNC_NAME)s(PyObject *arg, %(CTYPE)s *container)
         Py_ssize_t size = PyList_Size(arg);
         for (Py_ssize_t i = 0; i < size; i++) {
             %(ITEM_CTYPE)s item;
-            if (!%(ITEM_CONVERTER)s(PyList_GET_ITEM(arg, i), &item)) {
+            if (!%(ITEM_CONVERTER)s(PyList_GetItem(arg, i), &item)) {
                 return 0;
             }
             container->%(ADD_VALUE)s(item);
@@ -573,16 +587,16 @@ int %(CONTAINER_CONVERTER_FUNC_NAME)s(PyObject *arg, %(CTYPE)s *container)
         container->clear();
         Py_ssize_t size = PyList_Size(arg);
         for (Py_ssize_t i = 0; i < size; i++) {
-            PyObject *tup = PyList_GET_ITEM(arg, i);
+            PyObject *tup = PyList_GetItem(arg, i);
             if (!PyTuple_Check(tup) || PyTuple_Size(tup) != 2) {
                 PyErr_SetString(PyExc_TypeError, "items must be tuples with two elements");
                 return 0;
             }
             std::pair< %(KEY_CTYPE)s, %(ITEM_CTYPE)s > item;
-            if (!%(KEY_CONVERTER)s(PyTuple_GET_ITEM(tup, 0), &item.first)) {
+            if (!%(KEY_CONVERTER)s(PyTuple_GetItem(tup, 0), &item.first)) {
                 return 0;
             }
-            if (!%(ITEM_CONVERTER)s(PyTuple_GET_ITEM(tup, 1), &item.second)) {
+            if (!%(ITEM_CONVERTER)s(PyTuple_GetItem(tup, 1), &item.second)) {
                 return 0;
             }
             container->%(ADD_VALUE)s(item);
@@ -693,7 +707,7 @@ class ContainerParameter(ContainerParameterBase):
             self.container_type.pystruct+'*', 'py_'+self.container_type.name)
         wrapper.before_call.write_code(
             "%s = PyObject_New(%s, %s);" %
-            (self.py_name, self.container_type.pystruct, '&'+self.container_type.pytypestruct))
+            (self.py_name, self.container_type.pystruct, '_TYPEREF '+self.container_type.pytypestruct))
 
         wrapper.before_call.write_code("%s->obj = new %s(%s);" % (self.py_name, self.container_type.full_name, self.value))
 
@@ -728,7 +742,7 @@ class ContainerRefParameter(ContainerParameterBase):
                 self.container_type.pystruct+'*', 'py_'+self.container_type.name)
             wrapper.after_call.write_code(
                 "%s = PyObject_New(%s, %s);" %
-                (py_name, self.container_type.pystruct, '&'+self.container_type.pytypestruct))
+                (py_name, self.container_type.pystruct, '_TYPEREF '+self.container_type.pytypestruct))
             wrapper.after_call.write_code("%s->obj = new %s(%s);" % (py_name, self.container_type.full_name, container_tmp_var))
             wrapper.build_params.add_parameter("N", [py_name])
 
@@ -740,7 +754,7 @@ class ContainerRefParameter(ContainerParameterBase):
             self.container_type.pystruct+'*', 'py_'+self.container_type.name)
         wrapper.before_call.write_code(
             "%s = PyObject_New(%s, %s);" %
-            (self.py_name, self.container_type.pystruct, '&'+self.container_type.pytypestruct))
+            (self.py_name, self.container_type.pystruct, '_TYPEREF '+self.container_type.pytypestruct))
 
         if self.direction & Parameter.DIRECTION_IN:
             wrapper.before_call.write_code("%s->obj = new %s(%s);" % (self.py_name, self.container_type.full_name, self.name))
@@ -800,7 +814,7 @@ class ContainerPtrParameter(ContainerParameterBase):
 
             wrapper.after_call.write_code(
                 "%s = PyObject_New(%s, %s);" %
-                (py_name, self.container_type.pystruct, '&'+self.container_type.pytypestruct))
+                (py_name, self.container_type.pystruct, '_TYPEREF '+self.container_type.pytypestruct))
 
             wrapper.after_call.write_code("%s->obj = %s;" % (py_name, container_tmp_var))
 
@@ -855,7 +869,7 @@ class ContainerReturnValue(ContainerReturnValueBase):
 
         wrapper.after_call.write_code(
             "%s = PyObject_New(%s, %s);" %
-            (py_name, self.container_type.pystruct, '&'+self.container_type.pytypestruct))
+            (py_name, self.container_type.pystruct, '_TYPEREF '+self.container_type.pytypestruct))
         wrapper.after_call.write_code("%s->obj = new %s(%s);" % (self.py_name, self.container_type.full_name, self.value))
         wrapper.build_params.add_parameter("N", [py_name], prepend=True)
 

--- a/pybindgen/cppclass_container.py
+++ b/pybindgen/cppclass_container.py
@@ -135,7 +135,11 @@ typedef struct {
 
         ## --- register the iter type in the module ---
         module.after_init.write_code("/* Register the '%s' class iterator*/" % self.cppclass.full_name)
-        module.after_init.write_error_check('PyType_Ready(&%s)' % (self.iter_pytypestruct,))
+        module.after_init.write_error_check('PyType_Ready(_TYPEREF %s)' % (self.iter_pytypestruct,))
+        module.after_init.write_code('#ifdef Py_LIMITED_API')
+        module.after_init.write_code('%s = (PyTypeObject*)PyType_FromSpec(&%s_spec);\n'
+                                                 % (self.iter_pytypestruct, self.iter_pytypestruct))
+        module.after_init.write_code('#endif')
 
         if self.cppclass.outer_class is None:
             module.after_init.write_code(
@@ -238,7 +242,7 @@ static void
 static PyObject*
 %(CONTAINER_ITER_FUNC)s(%(PYSTRUCT)s *self)
 {
-    %(ITER_PYSTRUCT)s *iter = PyObject_GC_New(%(ITER_PYSTRUCT)s, &%(ITER_PYTYPESTRUCT)s);
+    %(ITER_PYSTRUCT)s *iter = PyObject_GC_New(%(ITER_PYSTRUCT)s, _TYPEREF %(ITER_PYTYPESTRUCT)s);
     Py_INCREF(self);
     iter->container = self;
     iter->iterator = new %(CTYPE)s::%(ITERATOR_TYPE)s(self->obj->%(BEGIN_METHOD)s());

--- a/pybindgen/enum.py
+++ b/pybindgen/enum.py
@@ -169,10 +169,15 @@ class Enum(object):
                 module.after_init.write_code(
                     ' // %s\n'
                     'tmp_value = PyLong_FromLong(%s);\n'
+                    '#ifdef Py_LIMITED_API\n'
+                    'PyObject_SetAttrString((PyObject*) %s, (char *) \"%s\", tmp_value);\n'
+                    '#else\n'
                     'PyDict_SetItemString((PyObject*) %s.tp_dict, \"%s\", tmp_value);\n'
+                    '#endif\n'
                     'Py_DECREF(tmp_value);'
                     % (
-                    value_str, value_str, self.outer_class.pytypestruct, value_name))
+                      value_str, value_str, self.outer_class.pytypestruct, value_name,
+                      self.outer_class.pytypestruct, value_name))
             module.after_init.unindent()
             module.after_init.write_code("}")
 

--- a/pybindgen/overloading.py
+++ b/pybindgen/overloading.py
@@ -238,7 +238,7 @@ class OverloadedWrapper(object):
             code_sink.writeln('error_list = PyList_New(%i);' % len(delegate_wrappers))
             for i in range(len(delegate_wrappers)):
                 code_sink.writeln(
-                    'PyList_SET_ITEM(error_list, %i, PyObject_Str(exceptions[%i]));'
+                    'PyList_SetItem(error_list, %i, PyObject_Str(exceptions[%i]));'
                     % (i, i))
                 code_sink.writeln("Py_DECREF(exceptions[%i]);" % i)
             code_sink.writeln('PyErr_SetObject(PyExc_TypeError, error_list);')

--- a/pybindgen/pytypeobject.py
+++ b/pybindgen/pytypeobject.py
@@ -2,7 +2,31 @@
 The class PyTypeObject generates a PyTypeObject structure contents.
 """
 
+
 class PyTypeObject(object):
+    LIMITED_API_TEMPLATE = (
+        'static PyType_Slot %(typestruct)s_slots[] = {\n'
+        '    {Py_tp_dealloc, (void*)%(tp_dealloc)s},\n'
+        '    {Py_tp_richcompare, (void*)%(tp_richcompare)s},\n'
+        '    {Py_tp_traverse, (void*)%(tp_traverse)s},\n'
+        '    {Py_tp_clear, (void*)%(tp_clear)s},\n'
+        '    {Py_tp_iter, (void*)%(tp_iter)s},\n'
+        '    {Py_tp_iternext, (void*)%(tp_iternext)s},\n'
+        '    {Py_tp_methods, (struct PyMethodDef*)%(tp_methods)s},\n'
+        '    {Py_tp_init, (void*)%(tp_init)s},\n'
+        '    {Py_tp_alloc, (void*)PyType_GenericAlloc},\n'
+        '    {Py_tp_new, (void*)PyType_GenericNew},\n'
+        '    {0, 0}\n'
+        '};\n'
+        'static PyType_Spec %(typestruct)s_spec = {\n'
+        '    (char *) "%(tp_name)s",\n'
+        '    %(tp_basicsize)s,\n'
+        '    0,\n'
+        '    %(tp_flags)s,\n'
+        '    %(typestruct)s_slots,\n'
+        '};\n\n'
+        'PyTypeObject *%(typestruct)s;\n'
+        )
     TEMPLATE = (
         'PyTypeObject %(typestruct)s = {\n'
         '    PyVarObject_HEAD_INIT(NULL, 0)\n'
@@ -103,7 +127,11 @@ class PyTypeObject(object):
         slots.setdefault('tp_free', '0')
         slots.setdefault('tp_is_gc', 'NULL')
 
+        code_sink.writeln('#ifdef Py_LIMITED_API')
+        code_sink.writeln(self.LIMITED_API_TEMPLATE % slots)
+        code_sink.writeln('#else')
         code_sink.writeln(self.TEMPLATE % slots)
+        code_sink.writeln('#endif')
 
 
 class PyNumberMethods(object):

--- a/pybindgen/utils.py
+++ b/pybindgen/utils.py
@@ -110,8 +110,26 @@ typedef intobjargproc ssizeobjargproc;
 ''')
 
     code_sink.writeln(r'''
+#ifdef Py_LIMITED_API
+#  define _TYPEDEC *
+#else
+#  define _TYPEDEC 
+#endif
+
+#ifdef Py_LIMITED_API
+# define _TYPEREF
+#else
+# define _TYPEREF &
+#endif
+
+#ifdef Py_LIMITED_API
+# define PBG_SETATTR(_type, _name, _value)  PyObject_SetAttrString((PyObject*) _type, (char *) _name, _value);
+#else
+# define PBG_SETATTR(_type, _name, _value)  PyDict_SetItemString((PyObject*) _type.tp_dict, _name, _value);
+#endif
+
 #if PY_VERSION_HEX >= 0x03000000
-#if PY_VERSION_HEX >= 0x03050000
+#if PY_VERSION_HEX >= 0x03050000 && !defined(Py_LIMITED_API)
 typedef PyAsyncMethods* cmpfunc;
 #else
 typedef void* cmpfunc;


### PR DESCRIPTION
Here's changes that were required to generate PEP384 compliant code for my use-case. It's likely missing various bits and pieces to be a complete implementation though.

Initially I considered adding an option to pybindgen that generates either stable API or traditional code, but in the end it made more sense to do it with preprocessor conditions. This does add a bit of length to the C output.

Didn't look into any new tests yet, `tests/wscript` ran successfully but not with `-DPy_LIMITED_API` for the moment.