### PR TITLE
Update settings.py

### DIFF
--- a/pybindgen/settings.py
+++ b/pybindgen/settings.py
@@ -56,7 +56,7 @@ wrapper registries.  A wrapper registry ensures that at most one
 python wrapper exists for each C/C++ object.
 """
 
-deprecated_virtuals = None
+deprecated_virtuals = False
 """
 Prior to PyBindGen version 0.14, the code generated to handle C++
 virtual methods required Python user code to define a _foo method in


### PR DESCRIPTION
deprecated_virtuals should be set to False (not None) to prevent warning messages during the virtual methods scanning.
As a matter of fact, None is equivalent to False, with the added warning message.