### PR TITLE
Ordered dicts and custom_names

### DIFF
--- a/pybindgen/module.py
+++ b/pybindgen/module.py
@@ -56,7 +56,7 @@ from pybindgen.converter_functions import PythonToCConverter, CToPythonConverter
 from pybindgen import utils
 import warnings
 import traceback
-
+import collections
 
 class MultiSectionFactory(object):
     """
@@ -248,7 +248,7 @@ class ModuleBase(dict):
         self.cpp_namespace_prefix = '::'.join(path)
 
         self.declarations = DeclarationsScope()
-        self.functions = {} # name => OverloadedFunction
+        self.functions = collections.OrderedDict() # name => OverloadedFunction
         self.classes = []
         self.containers = []
         self.exceptions = []


### PR DESCRIPTION
Uses an ordered dict to store class attributes/methods so file generation outputs them in the same order they were defined, useful if you want to use pybindgen to make a basic skeleton and hand edit the file. I do this often and found that having to reorder stuff manually isn't as fun as it sounds.

Also adds custom_name to class attributes.

Oh, and _generate_tp_richcompare apparently has an unneeded PYBINDGEN_UNUSED.