### PR TITLE
Add support for unordered_map

### DIFF
--- a/pybindgen/castxmlparser.py
+++ b/pybindgen/castxmlparser.py
@@ -1612,7 +1612,8 @@ pybindgen.settings.error_handler = ErrorHandler()
             container_type = 'hash_set'
         elif traits is container_traits.hash_multiset_traits:
             container_type = 'hash_multiset'
-        elif traits is container_traits.map_traits:
+        elif (traits is container_traits.map_traits
+              or traits is container_traits.unordered_map_traits):
             container_type = 'map'
             if hasattr(traits, "key_type"):
                 key_type = traits.key_type(definition)
@@ -1621,9 +1622,7 @@ pybindgen.settings.error_handler = ErrorHandler()
                               "so we don't support mapping types with this  pygccxml version (%r)"
                               % pygccxml.__version__)
                 return
-
-        elif (traits is container_traits.map_traits
-              or traits is container_traits.multimap_traits
+        elif (traits is container_traits.multimap_traits
               or traits is container_traits.hash_map_traits
               or traits is container_traits.hash_multimap_traits):
             return # maps not yet implemented

--- a/pybindgen/container.py
+++ b/pybindgen/container.py
@@ -91,6 +91,7 @@ container_traits_list = {
     'hash_set':		ContainerTraits(add_value_method='insert'),
     'hash_multiset':	ContainerTraits(add_value_method='insert'),
     'map':		ContainerTraits(add_value_method='insert', is_mapping=True),
+    'unordered_map':	ContainerTraits(add_value_method='insert', is_mapping=True),
 }
 
 # from wikipedia: """Deque is sometimes written dequeue, but this use
@@ -110,7 +111,7 @@ class Container(object):
         :param container_type: a string with the type of container,
             one of 'list', 'deque', 'queue', 'priority_queue',
             'vector', 'stack', 'set', 'multiset', 'hash_set',
-            'hash_multiset', 'map'
+            'hash_multiset', 'map', 'unordered_map'
 
         :param outer_class: if the type is defined inside a class, must be a reference to the outer class
         :type outer_class: None or L{CppClass}

--- a/tests/foo.cc
+++ b/tests/foo.cc
@@ -406,6 +406,29 @@ TestContainer::set_simple_map (SimpleStructMap map)
     return count;
 }
 
+SimpleStructUnorderedMap
+TestContainer::get_simple_unordered_map ()
+{
+    SimpleStructUnorderedMap retval;
+    for (int i = 0; i < 10; i++)
+    {
+        simple_struct_t val = {i};
+        std::ostringstream os;
+        os << i;
+        retval[os.str()] = val;
+    }
+    return retval;
+}
+
+int
+TestContainer::set_simple_unordered_map (SimpleStructUnorderedMap map)
+{
+    int count = 0;
+    m_simpleUnorderedMap = map;
+    for (SimpleStructUnorderedMap::iterator iter = m_simpleUnorderedMap.begin(); iter != m_simpleUnorderedMap.end(); iter++)
+        count += iter->second.xpto;
+    return count;
+}
 
 void
 TestContainer::get_vec (std::vector<std::string> &outVec)

--- a/tests/foo.h
+++ b/tests/foo.h
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <set>
 #include <exception>
 #include <algorithm>
@@ -806,6 +807,7 @@ struct simple_struct_t
 typedef std::vector<simple_struct_t> SimpleStructList;
 typedef std::vector<simple_struct_t> SimpleStructVec;
 typedef std::map<std::string, simple_struct_t> SimpleStructMap;
+typedef std::unordered_map<std::string, simple_struct_t> SimpleStructUnorderedMap;
 
 
 SimpleStructList get_simple_list ();
@@ -838,6 +840,9 @@ public:
     virtual SimpleStructMap get_simple_map ();
     virtual int set_simple_map (SimpleStructMap map);
 
+    virtual SimpleStructUnorderedMap get_simple_unordered_map ();
+    virtual int set_simple_unordered_map (SimpleStructUnorderedMap map);
+
     // -#- @outVec(direction=out) -#-
     void get_vec (std::vector<std::string> &outVec);
 
@@ -850,6 +855,7 @@ public:
 private:
     SimpleStructList m_simpleList;
     SimpleStructMap m_simpleMap;
+    SimpleStructUnorderedMap m_simpleUnorderedMap;
 
     std::vector<std::string> *m_vec;
 

--- a/wscript
+++ b/wscript
@@ -200,6 +200,10 @@ def configure(conf):
             conf.env.append_value('CXXFLAGS_PYEXT', '-fvisibility=hidden')
             conf.env.append_value('CCFLAGS_PYEXT', '-fvisibility=hidden')
 
+        # use -std=c++11 for gcc version < 7 (for unordered_map support)
+        if (conf.env['CXX_NAME'] == 'gcc' and [int(x) for x in conf.env['CC_VERSION']] < [7,0,0]):
+            conf.env.append_value('CXXFLAGS', '-std=c++11')
+
         # Add include path for our stdint.h replacement, if needed (pstdint.h)
         if not conf.check_nonfatal(header_name='stdint.h'):
             conf.env.append_value('CPPPATH', os.path.join(conf.curdir, 'include'))


### PR DESCRIPTION
ns-3 public APIs have started to use std::unordered_map.   I just enabled unordered_map the same way as std::map; not sure whether more is needed.