### PR TITLE
Fix collections import (needed for Python 3.10)

### DIFF
--- a/pybindgen/cppclass.py
+++ b/pybindgen/cppclass.py
@@ -39,7 +39,8 @@ import collections
 try:
     collectionsCallable = collections.Callable
 except AttributeError:
-    collectionsCallable = collections
+    import collections.abc
+    collectionsCallable = collections.abc.Callable
 
 try:
     set


### PR DESCRIPTION
Python 3.10 removed collections.Callable (replaced by collections.abc.Callable).