### PR TITLE
Move to Py_SET_TYPE from Assigning to Py_TYPE result

### DIFF
--- a/pybindgen/cppclass.py
+++ b/pybindgen/cppclass.py
@@ -1988,7 +1988,7 @@ typedef struct {
                                                  % (self.pytypestruct, basenum, base.pytypestruct))
 
         if metaclass is not None:
-            module.after_init.write_code('Py_TYPE(&%s) = &%s;' %
+            module.after_init.write_code('Py_SET_TYPE(&%s, &%s);' %
                                          (self.pytypestruct, metaclass.pytypestruct))
 
         module.after_init.write_error_check('PyType_Ready(&%s)'


### PR DESCRIPTION
Python developers have been trying to move away from assigning directly to the result of a call to `Py_TYPE` to using `Py_SET_TYPE` to accomplish the same results. The latter is now required, not just preferred.

I know @gjcarneiro that you have *many* more important things to do, but I hope that this helps!