### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,8 +198,7 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       }
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
 
 
 autoclass_content = "both"


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.